### PR TITLE
Add uBlock Origin agent

### DIFF
--- a/Personal List (uBo).txt
+++ b/Personal List (uBo).txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: Dutch Filter List
 ! Description:  
 !     A supplement for EasyList and EasyPrivacy on Dutch domains including anti-adblock


### PR DESCRIPTION
GitHub now supports syntax highlighting of adblock filter lists, but this requires the presence of the adblock agent